### PR TITLE
Test methods with base use case

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "eslint index.js"
+    "test": "npm run test:lint && npm run test:tape",
+    "test:tape": "./node_modules/.bin/tape test/test.js | ./node_modules/.bin/tap-spec",
+    "test:lint": "eslint index.js"
   },
   "keywords": [
     "pull-stream",
@@ -30,6 +32,7 @@
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
+    "nock": "^9.0.6",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.2"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,125 @@
 var test = require('tape')
 var nock = require('nock')
+var pull = require('pull-stream');
+var fetch = require('../');
 
 test('fetch contents regularly', function (t) {
-  nock('https://example.com')
-  .get
-})
+
+  t.test('fetch', function(t) {
+
+    t.test('result should be returned', function(t) {
+
+      var body;
+      nock('https://example.com')
+        .post('/')
+        .reply(function(uri, requestBody) {
+          body = requestBody;
+          return [201, 'ok'];
+        });
+
+      pull(
+        pull.values([ { foo: 'bar' } ]),
+        pull.map(JSON.stringify),
+        fetch('https://example.com/', { method: 'POST', body: 'application/json' }),
+        pull.asyncMap((resp, done) => {
+          return pull(resp, pull.collect(done))
+        }),
+        pull.drain((data) => {
+          t.equal(body, '{"foo":"bar"}', 'POST body was correctly sent');
+          t.deepEqual(data, [new Buffer('ok')], 'result is buffer containing response');
+        }, t.end));
+    });
+
+    t.test('fetch should should trigger completion callback', function(t) {
+
+      var body;
+      nock('https://example.com')
+        .post('/')
+        .reply(function(uri, requestBody) {
+          body = requestBody;
+          return [201, 'ok'];
+        });
+
+      pull(
+        pull.values([ { foo: 'bar' } ]),
+        pull.map(JSON.stringify),
+        fetch('https://example.com/', { method: 'POST', body: 'application/json' }),
+        pull.asyncMap((resp, done) => {
+          return pull(resp, pull.collect(done))
+        }),
+        pull.map(Buffer.concat),
+        pull.drain((data) => {
+          t.deepEqual(data, new Buffer('ok'), 'result is buffer containing response');
+        }, t.end));
+    });
+
+    nock.cleanAll();
+    t.end();
+  });
+
+  t.test('result', function(t) {
+
+    t.test('result should be returned', function(t) {
+
+      nock('https://example.com')
+        .get('/')
+        .reply(200, '{"msg": "success"}')
+
+      pull(
+        fetch.result('https://example.com'),
+        pull.drain((data) => {
+          t.deepEqual(data, new Buffer('{"msg": "success"}'), 'result is buffer containing response');
+        }, t.end));
+    });
+
+    t.test('result should trigger completion callback', function(t) {
+
+      nock('https://example.com')
+        .get('/')
+        .reply(200, '{"msg": "success"}')
+
+      pull(
+        fetch.result('https://example.com'),
+        pull.drain((data) => {
+          t.deepEqual(data, new Buffer('{"msg": "success"}'), 'result is buffer containing response');
+        }, t.end));
+    });
+
+    nock.cleanAll();
+    t.end();
+  });
+
+  t.test('json', function(t) {
+
+    t.test('result should be parsed and returned', function(t) {
+
+      nock('https://example.com')
+        .get('/')
+        .reply(200, '{"msg": "success"}')
+
+      pull(
+        fetch.json('https://example.com'),
+        pull.drain((data) => {
+          t.deepEqual(data, {'msg': 'success'}, 'returned json is parsed');
+        }, t.end));
+    });
+
+    t.test('json should trigger completion callback', function(t) {
+
+      nock('https://example.com')
+        .get('/')
+        .reply(200, '{"msg": "success"}')
+
+      pull(
+        fetch.json('https://example.com'),
+        pull.drain((data) => {
+          t.deepEqual(data, {'msg': 'success'}, 'response was received');
+        }, t.end));
+    });
+
+    nock.cleanAll()
+    t.end();
+  });
+
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -21,34 +21,10 @@ test('fetch contents regularly', function (t) {
         pull.values([ { foo: 'bar' } ]),
         pull.map(JSON.stringify),
         fetch('https://example.com/', { method: 'POST', body: 'application/json' }),
-        pull.asyncMap((resp, done) => {
-          return pull(resp, pull.collect(done))
-        }),
-        pull.drain((data) => {
-          t.equal(body, '{"foo":"bar"}', 'POST body was correctly sent');
-          t.deepEqual(data, [new Buffer('ok')], 'result is buffer containing response');
-        }, t.end));
-    });
-
-    t.test('fetch should should trigger completion callback', function(t) {
-
-      var body;
-      nock('https://example.com')
-        .post('/')
-        .reply(function(uri, requestBody) {
-          body = requestBody;
-          return [201, 'ok'];
-        });
-
-      pull(
-        pull.values([ { foo: 'bar' } ]),
-        pull.map(JSON.stringify),
-        fetch('https://example.com/', { method: 'POST', body: 'application/json' }),
-        pull.asyncMap((resp, done) => {
-          return pull(resp, pull.collect(done))
-        }),
+        pull.asyncMap((resp, done) => pull(resp, pull.collect(done))),
         pull.map(Buffer.concat),
         pull.drain((data) => {
+          t.equal(body, '{"foo":"bar"}', 'POST body was correctly sent');
           t.deepEqual(data, new Buffer('ok'), 'result is buffer containing response');
         }, t.end));
     });
@@ -60,19 +36,6 @@ test('fetch contents regularly', function (t) {
   t.test('result', function(t) {
 
     t.test('result should be returned', function(t) {
-
-      nock('https://example.com')
-        .get('/')
-        .reply(200, '{"msg": "success"}')
-
-      pull(
-        fetch.result('https://example.com'),
-        pull.drain((data) => {
-          t.deepEqual(data, new Buffer('{"msg": "success"}'), 'result is buffer containing response');
-        }, t.end));
-    });
-
-    t.test('result should trigger completion callback', function(t) {
 
       nock('https://example.com')
         .get('/')
@@ -101,19 +64,6 @@ test('fetch contents regularly', function (t) {
         fetch.json('https://example.com'),
         pull.drain((data) => {
           t.deepEqual(data, {'msg': 'success'}, 'returned json is parsed');
-        }, t.end));
-    });
-
-    t.test('json should trigger completion callback', function(t) {
-
-      nock('https://example.com')
-        .get('/')
-        .reply(200, '{"msg": "success"}')
-
-      pull(
-        fetch.json('https://example.com'),
-        pull.drain((data) => {
-          t.deepEqual(data, {'msg': 'success'}, 'response was received');
         }, t.end));
     });
 


### PR DESCRIPTION
A single test for each method's basic use case.

The tests for `result` and `json` are currently failing because `drain`'s `done` is never called.